### PR TITLE
Disable strongbox

### DIFF
--- a/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
+++ b/android/src/main/java/com/oblador/keychain/cipherStorage/CipherStorageBase.java
@@ -409,6 +409,10 @@ abstract public class CipherStorageBase implements CipherStorage {
       if (null == isStrongboxAvailable || isStrongboxAvailable.get()) {
         if (null == isStrongboxAvailable) isStrongboxAvailable = new AtomicBoolean(false);
 
+        /*
+        * StrongBox is not supported on all devices and was causing slowliness on some devices.
+        * https://github.com/oblador/react-native-keychain/issues/630
+        * Disabling it for temporarily.
         try {
           secretKey = tryGenerateStrongBoxSecurityKey(alias);
 
@@ -416,6 +420,7 @@ abstract public class CipherStorageBase implements CipherStorage {
         } catch (GeneralSecurityException | ProviderException ex) {
           Log.w(LOG_TAG, "StrongBox security storage is not available.", ex);
         }
+        */
       }
     }
 


### PR DESCRIPTION
# Description

This PR disables strongbox temporarily due to slow app startup. 

# How to test

We should guarantee that logged in users will be able to retrieve their already stored data with biometrics after this change. And also login and store for the first time.

- Run the app with the previous version, log in and enable biometrics
- Update package.json line 52 with the following `https://github.com/katharine-river/react-native-keychain#katharine/disable-strong-box`
- Run `yarn android` and unlock the phone with biometrics
- User biometrics should work and be faster
- Delete the app, run `yarn android` go though login flow and enable biometrics, close the app, open the app and unlock with biometrics, biometrics should work and be faster

To test a release build:
1. go to android/app/build.gradle
2. Update line 112 `signingConfig signingConfigs.debug` 
3. Add `debuggable true` in line 117
4. Run `./gradlew assembleRelease`
5. Install the release apk on physical device and test `adb install {path_to_android-app}/android-app/android/app/build/outputs/apk/release/app-release.apk`


